### PR TITLE
Add: Introducing GitHub PR Form Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+---
+# ScrollViewRTL Swift Package PR Form
+---
+
+# Description
+*Provide a detailed description of your changes:*
+
+- **Features Added:** [List any new features added.]
+- **Bugs Fixed:** [Specify the bugs that are fixed.]
+- **Improvements Made:** [Describe any enhancements or optimizations.]
+
+*Reason for the Change:*
+- [Explain why the change is necessary and its benefits.]
+
+*Approach Taken:*
+- [Briefly outline the approach you took to implement the changes.]
+
+Resolved Issues:
+*[Link to specific Jira issues or tasks that this PR addresses. If there are none, remove this section.]*
+
+## Type of Change
+- [ ] Bug Fix
+- [ ] New Feature
+- [ ] Change Request
+- [ ] Code Refactor
+- [ ] Update Dependencies
+- [ ] Other: *[Specify the type if not covered by the above options.]*
+
+## Checklist:
+*[Customize the checklist based on your project requirements. Examples provided are for reference.]*
+- [ ] Unit tests cover all new code with at least 80% coverage.
+- [ ] Code adheres to Swift and SwiftUI coding guidelines.
+- [ ] Documentation is updated to reflect the changes.
+- [ ] No sensitive information or debug code is included.
+- [ ] The PR has been reviewed by another developer.
+
+## Testing
+*[Describe the tests you performed to ensure the changes work as expected.]*
+- [ ] Automated tests cover specific scenarios.
+- [ ] Manual tests were performed, covering edge cases and potential limitations.
+- [ ] Additional testing steps or considerations: *[Specify if needed.]*
+
+## Related Issues
+*[Link to related PRs, discussions, or issues. If not applicable, remove this section.]*
+
+## Additional Tips:
+- [ ] Screenshots or GIFs demonstrating new features or bug fixes have been included.
+- [ ] Known limitations or potential issues with your changes are mentioned.
+- [ ] Encourage contributors to provide context and details in the PR description for better understanding.


### PR DESCRIPTION
This pull request introduces a temporary feature aimed at streamlining the process of creating new pull requests within our project. A GitHub PR form template has been added to ensure consistency and completeness in the information provided for each pull request.